### PR TITLE
Made change to be able to send argument dictionaries (as structs).

### DIFF
--- a/magento/magento_api.py
+++ b/magento/magento_api.py
@@ -199,6 +199,10 @@ class MagentoResource(object):
         path = '.'.join([self._name, method_name])
 
         def call_method(*args, **kwargs):
+            # If we don't have a list of arguments, pass a dictionary.
+            if not args:
+                args = kwargs
+
             return self._client.call(self._session_id, path, args)
         return call_method
 


### PR DESCRIPTION
Currently, only flat arrays of arguments are supported. This allows for both constructions to be sent.

For example, if you pass positional arguments, this is the XML-RPC payload:

``` xml
<array>
<data>
<value><int>314</int></value>
</data>
</array>
```

Now, if you pass keyword arguments:

``` xml
<struct>
<member>
<name>productIdentifierType</name>
<value><string>sku</string></value>
</member>
<member>
<name>productId</name>
<value><int>314</int></value>
</member>
</struct>
```

Unfortunately, Magenta doesn't currently take advantage of this. If you pass a struct, Magenta will ignore the argument names and take their values in order as if they were presented as an array. However, this will allow your library to accommodate it if they ever fix that rather than this library being the weak-link.
